### PR TITLE
Update TypeScript configuration to exclude 'resources' directory

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "src-tauri"]
+  "exclude": ["node_modules", "src-tauri", "resources"]
 }


### PR DESCRIPTION
Modify the TypeScript configuration to exclude the 'resources' directory from the compilation process.

fixes:

![image](https://github.com/user-attachments/assets/701787a2-160c-4651-a71a-9d592faf89ac)


