### PR TITLE
Disable ESLint rule for next/image component

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,7 @@
   "rules": {
     "@typescript-eslint/no-unused-vars": "warn",
     "@typescript-eslint/no-explicit-any": "warn",
-    "react-hooks/exhaustive-deps": "off"
+    "react-hooks/exhaustive-deps": "off",
+    "@next/next/no-img-element": "off"
   }
 }


### PR DESCRIPTION
Disable the ESLint rule for the next/image component 

![image](https://github.com/user-attachments/assets/edcfff57-c463-461c-a825-91796ec189ed)
