### PR TITLE
Add pull request trigger for Rust workflow on main branch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,6 +3,8 @@ name: Rust
 on:
   push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Introduce a pull request trigger for the main branch in the Rust workflow to enhance CI/CD processes.

this will make it easier to check if pull requests break the build process

when this is merged, we can test it on #27 