### PR TITLE
Add devEngines section to package.json for npm configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "engines": {
     "node": ">=20"
   },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm"
+    }
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
Introduce a `devEngines` section in `package.json` to specify the npm package manager for development environments.